### PR TITLE
Feature/web 3831 improve developer's test experience

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,6 +12,9 @@ omit =
     *manage.py
     *labsterutils/*
     *tox/*
+    *test_runner.py
+    *test_settings.py
+    *test_case.py
 
 concurrency=multiprocessing
 

--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ Quick start
 
 Test
 ----
-
-Create env file with following data:
-POSTGRES_DB=fill_value
-POSTGRES_USER=file_value
-POSTGRES_PASSWORD=fill_vale
-POSTGRES_HOST=fill
-POSTGRES_PORT=5435
-
+- Create .env file with following data (feel free to change as rquired):
+```shell script
+export POSTGRES_DB=test
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=testPass
+export POSTGRES_HOST=localhost
+export POSTGRES_PORT=5435
+```
 
 - pip install tox
-- run postgres
+- get your test postgres instnce running, see points below
 - source .env
 - tox
 
@@ -68,12 +68,17 @@ Tox runs pycodestyle, but not pylint, because pylint checks for Django dependenc
 ### Nuances
 
 #### PostgreSQL
+
+##### Dockerized PosgreSQL setup
+1. remember to fill out your .env file
+3. run `./test_run_postgres.sh`
+
+##### Quick standalone PostreSQL setup
 To install `psycopg2` you need install special packages on Ubuntu and on Mac: http://initd.org/psycopg/docs/install.html
 
 If on mac you will see `ld: library not found for -lssl`, then `brew upgrade openssl`
 and `export CPPFLAGS="-I/usr/local/opt/openssl/include"`, `export LDFLAGS="-L/usr/local/opt/openssl/lib"`.
 
-##### Quick PostreSQL setup
 1. You can set `export PGDATA='full-path-to/Labster.oauth2_client/psql_data'`
 2. init_db
 3. pg_ctl -D /Users/kry/repos/labster/Labster.oauth2_client/psql_data -l logfile start

--- a/oauth2_client/tests/test_client.py
+++ b/oauth2_client/tests/test_client.py
@@ -3,16 +3,13 @@ Client tests.
 """
 import time
 
-from django.test import TestCase
 from django.utils import timezone
 
-from oauth2_client.client import get_client, TIMEOUT_SECONDS
-from oauth2_client.models import AccessToken
+from test_case import StandaloneAppTestCase
 from .test_compat import patch
-from .factories import AccessTokenFactory, ApplicationFactory
 
 
-class CreateAccessTokenTest(TestCase):
+class CreateAccessTokenTest(StandaloneAppTestCase):
     """
     Ouath2 client test cases.
     """
@@ -22,6 +19,10 @@ class CreateAccessTokenTest(TestCase):
         """
         Ensure new token is created if there is no token.
         """
+        from oauth2_client.models import AccessToken
+        from oauth2_client.client import get_client
+        from .factories import ApplicationFactory
+
         app = ApplicationFactory()
         token = {'access_token': 'my_token', 'expires_at': time.time()}
         get_token_mock.return_value = token
@@ -37,6 +38,10 @@ class CreateAccessTokenTest(TestCase):
         """
         Ensure no token is created if there is no expired one.
         """
+        from oauth2_client.models import AccessToken
+        from oauth2_client.client import get_client, TIMEOUT_SECONDS
+        from .factories import AccessTokenFactory, ApplicationFactory
+
         app = ApplicationFactory()
         token = {'access_token': 'my_token', 'expires_at': time.time() + TIMEOUT_SECONDS + 1}
         access_token = AccessTokenFactory(token=token, application=app)
@@ -51,6 +56,11 @@ class CreateAccessTokenTest(TestCase):
         """
         Ensure new token is created if there is expired one.
         """
+        from oauth2_client.models import AccessToken
+        from oauth2_client.client import get_client
+        from .factories import ApplicationFactory, AccessTokenFactory
+        from oauth2_client.client import TIMEOUT_SECONDS
+
         app = ApplicationFactory()
         curr_token = {'access_token': 'curr_token', 'expires_at': time.time() + TIMEOUT_SECONDS - 1}
         AccessTokenFactory(

--- a/test_case.py
+++ b/test_case.py
@@ -1,0 +1,33 @@
+import django
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase
+
+from test_settings import TEST_SETTINGS
+
+
+def setup_django():
+    if not settings.configured:
+        settings.configure(**TEST_SETTINGS)
+        # https://docs.djangoproject.com/en/1.11/topics/settings/#calling-django-setup-is-required-for-standalone-django-usage
+        django.setup()
+        # applying migrations manually is needed only for running from within GUI
+        call_command('migrate')
+    else:
+        # this is the case when the tests are running in a context of some external django application, everything
+        # is already set up so we don't have to do anything here
+        pass
+
+
+class StandaloneAppTestCase(TestCase):
+    """
+    This is project is django app without a django project.
+    This class makes developers able to run test cases directly in their
+    IDE, bypassing the `test_runner.py` script.
+    This does NOT automate the posgres setup.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        setup_django()
+        super(StandaloneAppTestCase, cls).setUpClass()

--- a/test_run_postgres.sh
+++ b/test_run_postgres.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+source ./.env
+
+docker run --name postgres-oauth2client \
+	-e "POSTGRES_DB=$POSTGRES_DB" \
+	-e "POSTGRES_USER=$POSTGRES_USER" \
+	-e "POSTGRES_PASSWORD=$POSTGRES_PASSWORD" \
+	-p $POSTGRES_PORT:5432 \
+	-d \
+	postgres:9.6.9

--- a/test_runner.py
+++ b/test_runner.py
@@ -11,31 +11,11 @@ We have services with different versions of Python:
 Python 2.7 for Simlic and Python3 for License Service.
 We have wrapper in `compat.py` that allows module to work in given python versions,
 """
-import django, sys, os
+import sys
 
-from django.conf import settings
+from test_case import setup_django
 
-
-# read from env and set in tox.
-settings.configure(
-    DEBUG=True,
-    DATABASES={
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': os.environ['POSTGRES_DB'],
-            'USER': os.environ['POSTGRES_USER'],
-            'PASSWORD': os.environ['POSTGRES_PASSWORD'],
-            'HOST': os.environ['POSTGRES_HOST'],
-            'PORT': os.environ.get('POSTGRES_PORT', '5432')
-        }
-    },
-    INSTALLED_APPS=(
-        'django.contrib.auth',
-        'django.contrib.contenttypes',
-        'django.contrib.sessions',
-        'oauth2_client',
-    )
-)
+setup_django()
 
 try:
     # Django < 1.8
@@ -43,7 +23,6 @@ try:
     test_runner = DjangoTestSuiteRunner(verbosity=1)
 except ImportError:
     # Django >= 1.8
-    django.setup()
     from django.test.runner import DiscoverRunner
     test_runner = DiscoverRunner(verbosity=1)
 

--- a/test_runner.py
+++ b/test_runner.py
@@ -26,7 +26,7 @@ settings.configure(
             'USER': os.environ['POSTGRES_USER'],
             'PASSWORD': os.environ['POSTGRES_PASSWORD'],
             'HOST': os.environ['POSTGRES_HOST'],
-            'POST': os.environ.get('POSTGRES_PORT', '5432')
+            'PORT': os.environ.get('POSTGRES_PORT', '5432')
         }
     },
     INSTALLED_APPS=(

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,0 +1,25 @@
+import os
+
+"""
+Defaults are used when running from the IDE.
+"""
+
+TEST_SETTINGS = {
+    'DEBUG': True,
+    'DATABASES': {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': os.environ.get('POSTGRES_DB', 'test'),
+            'USER': os.environ.get('POSTGRES_USER', 'postgres'),
+            'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'testPass'),
+            'HOST': os.environ.get('POSTGRES_HOST', 'localhost'),
+            'PORT': os.environ.get('POSTGRES_PORT', '5435')
+        }
+    },
+    'INSTALLED_APPS': [
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'oauth2_client',
+    ]
+}


### PR DESCRIPTION
- provided a short script to run a dockerized postgres instance for testing
- fixed a typo in settings, so .env file is fully used now (s/POST/PORT)
- added a parent test class, so devs are able to run tests from IDE now
- decoupled test settings from the test_runner.py
- made sure tox works fine, backward compatibility is maintained 