### PR TITLE
feature/WEB-3928: add dependencies to setup.py, update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,3 @@ folder.
 #### Coverage
 If coverage is installed globally, it can take wrong version inside virtualenv,
 so better uninstall it.
-
-### Release History
--------------------
-#### 0.2.0
-- add JWT grant type support, enable communication with Salesforce
-- add `oauth2provider_app` and `oauth2client_app` Django management commands.
-For creating OAuth Application model instances on both Client and Provider sides
-- automate development environment setup
-- add requirements to `setup.py`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Tested with a standard 3rd party `oauth2_provider` Django application from
 
 Supported Versions
 ------------------
-- Python 2.7 and Django 1.11,
+- Python 2.7 and Django 1.11
 - Python 3.7 and Django 2.2
 - PostgreSQL >= 9.6.9
 

--- a/README.md
+++ b/README.md
@@ -18,40 +18,58 @@ Tested with a standard 3rd party `oauth2_provider` Django application from
 
 Supported Versions
 ------------------
-Python 2.7 and Django 1.11,
-Python 3.7 and Django 2.2
+- Python 2.7 and Django 1.11,
+- Python 3.7 and Django 2.2
+- PostgreSQL >= 9.6.9
+
+Other versions may likely work too, but are not supported.
 
 Python and Django compatibility is maintained in `compat.py` and `test_compat.py`
 
-Quick Start
------------
+### Installation
+-------------
+#### Extras
+As of version `0.2.0` this project provides two extras, `SF` and `providerApp`:
+- `SF` - enables Salesforce JWT grant type support
+- `providerApp` - enables `oauth2_provider.Application` creation by means of
+a `oauth2provider_app` Django management command
 
-0. In requirements, add `pip install git+https://git@github.com/Livit/Labster.OAuth2Client.git@0.1.3`
+Vanilla install, without extras, makes you able to:
+- talk to systems that use `client-credentials` grant type
 
-1. Add "oauth2_client" to your INSTALLED_APPS setting like this:
+#### Steps
+-----
+1. In requirements, add `git+https://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0` or
+`git+ssh://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0#egg=oauth2-client[SF,providerApp]`,
+depending on if you need the extras
+
+2. Add "oauth2_client" to your INSTALLED_APPS settings. If you installed also `providerApp`
+extras, you have to add also `oauth2_provider`
 
 ```
     INSTALLED_APPS = [
         ...
+        'oauth2_provider',  # only for `providerApp` extras
         'oauth2_client',
     ]
 ```
 
-2. Run migrate to create the oauth2_client models.
+3. Run `python manage.py migrate` to create oauth2_client models.
 
-3. On the receiver side, create Application model and fill with proper data:
-
+4. On the receiver side, create Application model and fill with proper data, e.g.:
+```
     {
         name="Client name",
         redirect_uris="http://localhost",  # for local development
         client_type=Application.CLIENT_CONFIDENTIAL,
         authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
     }
+```
 
-4. On the client side, create oauth2_client.Application model instance, and
+5. On the client side, create `oauth2_client.Application` model instance, and
 populate it. You can get help by calling `python manage.py oauth2client_app -h`.
 
-5. Instantiate the client via library calls, and use it for all api calls.
+6. Instantiate the client via library calls, and use it for all api calls.
 
 
 Tests and Development
@@ -142,3 +160,12 @@ folder.
 #### Coverage
 If coverage is installed globally, it can take wrong version inside virtualenv,
 so better uninstall it.
+
+### Release History
+-------------------
+#### 0.2.0
+- add JWT grant type support, enable communication with Salesforce
+- add `oauth2provider_app` and `oauth2client_app` Django management commands.
+For creating OAuth Application model instances on both Client and Provider sides
+- automate development environment setup
+- add requirements to `setup.py`

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ Python and Django compatibility is maintained in `compat.py` and `test_compat.py
 ### Installation
 -------------
 #### Extras
-As of version `0.2.0` this project provides two extras, `SF` and `providerApp`:
-- `SF` - enables Salesforce JWT grant type support
-- `providerApp` - enables `oauth2_provider.Application` creation by means of
-a `oauth2provider_app` Django management command
+As of version `0.2.0` this project provides two extras, `JWT_grant` and `oauth2provider_command`:
+- `JWT_grant` - enables JWT grant type support, used e.g. by Salesforce. See
+[RFC](https://tools.ietf.org/html/rfc7523)
+- `oauth2provider_command` - enables `oauth2_provider.Application` creation by means of
+an `oauth2provider_app` Django management command
 
 Vanilla install, without extras, makes you able to:
 - talk to systems that use `client-credentials` grant type
@@ -40,10 +41,10 @@ Vanilla install, without extras, makes you able to:
 #### Steps
 -----
 1. In requirements, add `git+https://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0` or
-`git+ssh://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0#egg=oauth2-client[SF,providerApp]`,
+`git+ssh://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0#egg=oauth2-client[JWT_grant,oauth2provider_command]`,
 depending on if you need the extras
 
-2. Add "oauth2_client" to your INSTALLED_APPS settings. If you installed also `providerApp`
+2. Add "oauth2_client" to your INSTALLED_APPS settings. If you installed also `oauth2provider_command`
 extras, you have to add also `oauth2_provider`
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+
 from setuptools import find_packages, setup
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
@@ -27,8 +28,25 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
+    install_requires=[
+        'django>=1.11.17,<=1.11.24;python_version=="2.7"',
+        'django>=2.2;python_version>="3.7"',
+        'psycopg2 >= 2.7.3',
+        'pybreaker>=0.6.0',
+        'requests_oauthlib>=1.2.0',
+        'retrying>=1.3.3',
+    ],
+    extras_require={
+        "providerApp": [
+            'django-oauth-toolkit==1.0.0;python_version=="2.7"',
+            'django-oauth-toolkit>=1.2.0;python_version>="3.7"',
+        ],
+        "SF": [
+            'cryptography>=2.8',
+        ],
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,11 @@ setup(
         'retrying>=1.3.3',
     ],
     extras_require={
-        "providerApp": [
+        "oauth2provider_command": [
             'django-oauth-toolkit==1.0.0;python_version=="2.7"',
             'django-oauth-toolkit>=1.2.0;python_version>="3.7"',
         ],
-        "SF": [
+        "JWT_grant": [
             'cryptography>=2.8',
         ],
     }


### PR DESCRIPTION
Scope:
- add project dependencies to `setup.py`, to enable complete installation with pip. Dependencies are re-conciliated against LTI and CookieCutter, to ensure no warnings during installation
- dependencies use pip's concept of `extras`, as some are not mandatory for whole project
- update instructions in Readme.md 

Testing steps performed:
- set up a vanilla django project, install OAuth2Client, make sure requested dependencies are installed and project works fine. Tested use of commands and ran the client. Done with python2.7 and python3.7. No problems noticed. 

Jira: https://liv-it.atlassian.net/browse/WEB-3928?atlOrigin=eyJpIjoiNWFjYWE5ZjNmNGVkNDZjM2I1ZTY4MjQyNDk3ZWZlMWMiLCJwIjoiaiJ9