### PR TITLE
update Readme.md install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Vanilla install, without extras, makes you able to:
 #### Steps
 -----
 1. Add installation URI in requirements. Choose URI schema that works best for your case. They differ in syntax, to keep pip and pip-compile happy:
-- no hasing and no extras: `git+https://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0`
+- no hashing and no extras: `git+https://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0`
 - extras needed but no hashing required: `git+ssh://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0#egg=oauth2-client[JWT_grant,oauth2provider_command]`
 - extras needed and `pip-compile --generate-hashes` required: `https://github.com/Livit/Labster.OAuth2Client/archive/v0.2.0.zip#egg=oauth2-client[JWT_grant,oauth2provider_command]`
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Vanilla install, without extras, makes you able to:
 
 #### Steps
 -----
-1. In requirements, add `git+https://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0` or
-`git+ssh://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0#egg=oauth2-client[JWT_grant,oauth2provider_command]`,
-depending on if you need the extras
+1. Add installation URI in requirements. Choose URI schema that works best for your case. They differ in syntax, to keep pip and pip-compile happy:
+- no hasing and no extras: `git+https://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0`
+- extras needed but no hashing required: `git+ssh://git@github.com/Livit/Labster.OAuth2Client.git@0.2.0#egg=oauth2-client[JWT_grant,oauth2provider_command]`
+- extras needed and `pip-compile --generate-hashes` required: `https://github.com/Livit/Labster.OAuth2Client/archive/v0.2.0.zip#egg=oauth2-client[JWT_grant,oauth2provider_command]`
 
 2. Add "oauth2_client" to your INSTALLED_APPS settings. If you installed also `oauth2provider_command`
 extras, you have to add also `oauth2_provider`


### PR DESCRIPTION
Update setup instructions in readme, to support `pip-compile --generate-hashes` if needed.