### PR TITLE
WEB-3976: upgrade dependencies: django-oauth-toolkit and requests_oauthlib

### DIFF
--- a/requirements/tox_requirements27.txt
+++ b/requirements/tox_requirements27.txt
@@ -1,9 +1,9 @@
 mock==3.0.5
-requests_oauthlib==1.2.0
+requests_oauthlib==1.3.0
 cryptography==2.8
 ddt==1.2.2
-django==1.11.24
-django-oauth-toolkit==1.0.0  # not needed in production, unless you need to create provider's Applications
+django==1.11.17
+django-oauth-toolkit==1.1.3  # not needed in production, unless you need to create provider's Applications
 psycopg2==2.8.3
 factory_boy==2.12.0
 pybreaker==0.6.0

--- a/requirements/tox_requirements37.txt
+++ b/requirements/tox_requirements37.txt
@@ -1,4 +1,4 @@
-requests_oauthlib==1.2.0
+requests_oauthlib==1.3.0
 cryptography==2.8
 ddt==1.2.2
 django>=2.2

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,12 @@ setup(
         'django>=2.2;python_version>="3.7"',
         'psycopg2 >= 2.7.3',
         'pybreaker>=0.6.0',
-        'requests_oauthlib>=1.2.0',
+        'requests_oauthlib>=1.3.0',
         'retrying>=1.3.3',
     ],
     extras_require={
         "oauth2provider_command": [
-            'django-oauth-toolkit==1.0.0;python_version=="2.7"',
+            'django-oauth-toolkit==1.1.3;python_version=="2.7"',
             'django-oauth-toolkit>=1.2.0;python_version>="3.7"',
         ],
         "JWT_grant": [


### PR DESCRIPTION
… this is to match similar changes already made in LTI. Plus downgrade tested version of django in python2 build to match the one we use in LTI repo. Only minor version bumps.

Equivalent PR in LTI [is here](https://github.com/Livit/Livit.Learn.LTI/pull/1434).

**Jira:** https://liv-it.atlassian.net/browse/WEB-3976
