### PR TITLE
WEB-4006: use trufflehog from 3rd party docker image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,7 +79,6 @@ steps:
   pull: default
   image: dxa4481/trufflehog
   commands:
-  - ls -l
   - trufflehog --exclude_paths trufflehog-exclude.txt --regex .
   when:
     event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -79,7 +79,6 @@ steps:
   pull: default
   image: dxa4481/trufflehog
   commands:
-  - apk --update add bash
   - trufflehog --exclude_paths trufflehog-exclude.txt --regex .
   when:
     event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -79,6 +79,7 @@ steps:
   pull: default
   image: dxa4481/trufflehog
   commands:
+  - ls -l
   - trufflehog --exclude_paths trufflehog-exclude.txt --regex .
   when:
     event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,10 +77,9 @@ steps:
 
 - name: secrets leaks test
   pull: default
-  image: python:3.7.3-alpine3.8
+  image: dxa4481/trufflehog
   commands:
-  - apk --update add bash git
-  - pip install -r requirements/development.txt
+  - apk --update add bash
   - trufflehog --exclude_paths trufflehog-exclude.txt --regex .
   when:
     event:

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,3 @@ quality: pylint pycodestyle
 
 test: ## Run unit tests.
 		tox
-
-trufflehog: ## Run trufflehog secret leaks tool
-trufflehog:
-		./.venv/bin/trufflehog --exclude_paths trufflehog-exclude.txt --regex . && \
-		echo "All good"

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,2 +1,1 @@
 tox==3.14.0
-truffleHog==2.0.99


### PR DESCRIPTION
Trufflehog pip package is currently broken. Implementing a recommended fix to get the build working and product releasable. 
Jira [is here](https://liv-it.atlassian.net/browse/WEB-4006)