### PR TITLE
TESLA-1308/update-to-django-1.11.23

### DIFF
--- a/requirements/tox_requirements27.txt
+++ b/requirements/tox_requirements27.txt
@@ -2,7 +2,7 @@ mock==3.0.5
 requests_oauthlib==1.3.0
 cryptography==2.8
 ddt==1.2.2
-django==1.11.17
+django==1.11.23
 django-oauth-toolkit==1.1.3  # not needed in production, unless you need to create provider's Applications
 psycopg2==2.8.3
 factory_boy==2.12.0


### PR DESCRIPTION
Django really should be upgraded to 1.11.29, but this removes critical issues.