### PR TITLE
TESLA-1469 clear out harmful migration that truncates client secrets

### DIFF
--- a/oauth2_client/migrations/0002_auto_20191003_1947.py
+++ b/oauth2_client/migrations/0002_auto_20191003_1947.py
@@ -11,10 +11,10 @@ class Migration(migrations.Migration):
         ('oauth2_client', '0001_initial'),
     ]
 
+    #
+    # This migration has been retrospectively cleared out, as it contained an
+    # operation that led to application.client_secret being truncated
+    # https://liv-it.atlassian.net/browse/TESLA-1469
+    #
     operations = [
-        migrations.AlterField(
-            model_name='application',
-            name='client_secret',
-            field=models.CharField(max_length=100),
-        ),
     ]


### PR DESCRIPTION
Jira with test report and more information: https://liv-it.atlassian.net/browse/TESLA-1469

Tests gave positive results:
- migrations can be rolled back and forth
- data is preserved
- truncation doesn’t happen anymore
